### PR TITLE
feat: upgrade Schema validation to use `ajv`

### DIFF
--- a/integration-test/postgresql/auth.test.ts
+++ b/integration-test/postgresql/auth.test.ts
@@ -85,7 +85,7 @@ describe('No token', () => {
           method: 'POST',
           href: '/token',
           schema: {
-            $schema: 'http://json-schema.org/draft-04/schema#',
+            $schema: 'http://json-schema.org/draft-07/schema#',
             title: 'token',
             type: 'object',
             properties: {
@@ -317,7 +317,7 @@ describe('Valid token', () => {
         method: 'POST',
         href: '/token',
         schema: {
-          $schema: 'http://json-schema.org/draft-04/schema#',
+          $schema: 'http://json-schema.org/draft-07/schema#',
           title: 'token',
           type: 'object',
           properties: {

--- a/integration-test/postgresql/common.ts
+++ b/integration-test/postgresql/common.ts
@@ -430,9 +430,9 @@ describe('POST /tasks (CreateItem - Invalid Data)', () => {
 
     expect(body.errors).toEqual([{
       dataPath: '',
-      schemaPath: '/required/0',
-      message: 'Missing required property: title',
-      params: { key: 'title' }
+      schemaPath: '#/required',
+      message: "should have required property 'title'",
+      params: { missingProperty: 'title' }
     }]);
   });
 
@@ -467,8 +467,12 @@ describe('POST /tasks (CreateItem - Constraint violation)', () => {
 
     expect(body.errors).toEqual([{
       dataPath: '/project',
-      schemaPath: '/properties/project/constraint',
-      message: 'Constraint violation'
+      schemaPath: '#/properties/project/constraint',
+      message: 'Constraint violation',
+      keyword: 'x-prism-constraint',
+      params: {
+        'x-prism-constraint': 'project'
+      }
     }]);
   });
 
@@ -650,26 +654,20 @@ describe('POST /tasks (CreateItem - Invalid embedded Project)', () => {
     var body = await response.json();
 
     expect(body.errors).toEqual([{
-      dataPath: '/project',
-      message: 'Data does not match any schemas from "oneOf"',
-      params: {},
-      schemaPath: '/properties/project/oneOf',
-      subErrors: [{
-        dataPath: '/project',
-        message: 'Invalid type: object (expected number)',
-        schemaPath: '/properties/project/oneOf/0/type',
-        params: {
-          expected: 'number',
-          type: 'object'
-        }
-      }, {
-        dataPath: '/project',
-        message: 'Missing required property: name',
-        schemaPath: '/properties/project/oneOf/1/required/0',
-        params: {
-          key: 'name'
-        }
-      }]
+      dataPath: "/project",
+      message: "should be number",
+      params: { type: "number" },
+      schemaPath: "#/properties/project/oneOf/0/type"
+    }, {
+      dataPath: "/project",
+      message: "should have required property 'name'",
+      params: { missingProperty: "name" },
+      schemaPath: "#/properties/project/oneOf/1/required"
+    }, {
+      dataPath: "/project",
+      message: "should match exactly one schema in oneOf",
+      params: { "passingSchemas": null },
+      schemaPath: "#/properties/project/oneOf"
     }]);
   });
 
@@ -715,8 +713,12 @@ describe('POST /tasks (CreateItem - Embedded User constraint violation)', () => 
 
     expect(body.errors).toEqual([{
       dataPath: '/department',
-      schemaPath: '/properties/department/constraint',
-      message: 'Constraint violation'
+      schemaPath: '#/properties/department/constraint',
+      message: 'Constraint violation',
+      keyword: 'x-prism-constraint',
+      params: {
+        'x-prism-constraint': 'department'
+      }
     }]);
   });
 
@@ -799,12 +801,9 @@ describe('PATCH /tasks/2 (UpdateItem - Invalid data)', () => {
 
     expect(body.errors).toEqual([{
       dataPath: '/title',
-      message: 'Invalid type: number (expected string)',
-      params: {
-        expected: 'string',
-        type: 'number'
-      },
-      schemaPath: '/properties/title/type'
+      message: 'should be string',
+      params: { type: 'string' },
+      schemaPath: '#/properties/title/type'
     }]);
   });
 
@@ -847,7 +846,11 @@ describe('PATCH /tasks/2 (UpdateITem - Constraint Violation)', () => {
     expect(body.errors).toEqual([{
       dataPath: '/project',
       message: 'Constraint violation',
-      schemaPath: '/properties/project/constraint'
+      schemaPath: '#/properties/project/constraint',
+      keyword: 'x-prism-constraint',
+      params: {
+        'x-prism-constraint': 'project'
+      }
     }]);
   })
 
@@ -943,27 +946,22 @@ describe('PATCH /tasks/2 (UpdateItem - Invalid embedded Project)', () => {
     var body = await response.json();
 
     expect(body.errors).toEqual([{
-      dataPath: '/project',
-      message: 'Data does not match any schemas from "oneOf"',
-      schemaPath: '/properties/project/oneOf',
-      params: {},
-      subErrors: [{
-        dataPath: '/project',
-        message: 'Invalid type: object (expected number)',
-        schemaPath: '/properties/project/oneOf/0/type',
-        params: {
-          expected: 'number',
-          type: 'object'
-        }
-      }, {
-        dataPath: '/project',
-        message: 'Missing required property: name',
-        schemaPath: '/properties/project/oneOf/1/required/0',
-        params: {
-          key: 'name'
-        }
-      }]
+      dataPath: "/project",
+      message: "should be number",
+      params: { type: "number" },
+      schemaPath: "#/properties/project/oneOf/0/type"
+    }, {
+      dataPath: "/project",
+      message: "should have required property 'name'",
+      params: { missingProperty: "name" },
+      schemaPath: "#/properties/project/oneOf/1/required"
+    }, {
+      dataPath: "/project",
+      message: "should match exactly one schema in oneOf",
+      params: { passingSchemas: null },
+      schemaPath: "#/properties/project/oneOf"
     }]);
+
   });
 
   it('does not modify the Task', async () => {

--- a/integration-test/postgresql/common/schemas.ts
+++ b/integration-test/postgresql/common/schemas.ts
@@ -1,5 +1,5 @@
 export const departments = {
-  $schema: "http://json-schema.org/draft-04/schema#",
+  $schema: "http://json-schema.org/draft-07/schema#",
   title: 'departments',
   type: 'object',
   properties: {
@@ -10,7 +10,7 @@ export const departments = {
 };
 
 export const users = {
-  $schema: "http://json-schema.org/draft-04/schema#",
+  $schema: "http://json-schema.org/draft-07/schema#",
   title: 'users',
   type: 'object',
   properties: {
@@ -28,7 +28,7 @@ export const users = {
 };
 
 export const projects = {
-  $schema: "http://json-schema.org/draft-04/schema#",
+  $schema: "http://json-schema.org/draft-07/schema#",
   title: 'projects',
   type: 'object',
   properties: {
@@ -40,7 +40,7 @@ export const projects = {
 };
 
 export const tasks = {
-  $schema: "http://json-schema.org/draft-04/schema#",
+  $schema: "http://json-schema.org/draft-07/schema#",
   title: 'tasks',
   type: 'object',
   properties: {

--- a/integration-test/postgresql/package.json
+++ b/integration-test/postgresql/package.json
@@ -13,7 +13,7 @@
     "@optics/prism": "file:../../build",
     "@types/hapi": "18.0.0",
     "@types/node-fetch": "^1.6.7",
-    "collimator": "^5.1.1",
+    "collimator": "7.0.0",
     "hapi": "18.0.0",
     "jest": "23.6.0",
     "node-fetch": "^1.6.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1039,9 +1039,9 @@
       }
     },
     "@types/jest": {
-      "version": "16.0.7",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-16.0.7.tgz",
-      "integrity": "sha1-ZyOMGFaZaoJzvGwEorRmUh4CHOk=",
+      "version": "23.3.13",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-23.3.13.tgz",
+      "integrity": "sha512-ePl4l+7dLLmCucIwgQHAgjiepY++qcI6nb8eAwGNkB6OxmTe3Z9rQU3rSpomqu42PCCnlThZbOoxsf+qylJsLA==",
       "dev": true
     },
     "@types/joi": {
@@ -1106,12 +1106,6 @@
       "requires": {
         "@types/node": "*"
       }
-    },
-    "@types/tv4": {
-      "version": "1.2.28",
-      "resolved": "https://registry.npmjs.org/@types/tv4/-/tv4-1.2.28.tgz",
-      "integrity": "sha1-C72jW/SoXZ5b5WoAUZmBy55AjNU=",
-      "dev": true
     },
     "@types/uri-templates": {
       "version": "0.1.28",
@@ -1193,10 +1187,9 @@
       }
     },
     "ajv": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.7.0.tgz",
-      "integrity": "sha512-RZXPviBTtfmtka9n9sy1N5M5b82CbxWIR6HIis4s3WQTXDJamc/0gpCWNGz6EWdWp4DOfjzJfhz/AS9zVPjjWg==",
-      "dev": true,
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4010,8 +4003,7 @@
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-      "dev": true
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
     "fast-glob": {
       "version": "2.2.6",
@@ -4342,8 +4334,7 @@
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -7319,8 +7310,7 @@
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -11772,8 +11762,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "q": {
       "version": "1.5.1",
@@ -13811,11 +13800,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "tv4": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/tv4/-/tv4-1.3.0.tgz",
-      "integrity": "sha1-0CDIRvrdUMhVq7JeuuzGj8EPeWM="
-    },
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
@@ -13971,7 +13955,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -13,11 +13,10 @@
     "@types/boom": "7.2.1",
     "@types/hapi": "18.0.0",
     "@types/hapi-auth-jwt2": "8.0.2",
-    "@types/jest": "^16.0.1",
+    "@types/jest": "^23.3.13",
     "@types/jsonwebtoken": "^7.2.0",
     "@types/lodash": "^4.14.53",
     "@types/ramda": "^0.25.8",
-    "@types/tv4": "^1.2.28",
     "@types/uri-templates": "^0.1.28",
     "commitlint": "^7.3.2",
     "fs-extra-promise": "^0.4.1",
@@ -33,6 +32,7 @@
     "esnext": true
   },
   "dependencies": {
+    "ajv": "^6.10.0",
     "bcrypt": "3.0.3",
     "boom": "7.3.0",
     "hapi-auth-jwt2": "8.3.0",
@@ -41,7 +41,6 @@
     "pg-promise": "^7.3.2",
     "ramda": "^0.22.1",
     "squel": "^5.12.0",
-    "tv4": "^1.2.7",
     "uri-templates": "^0.2.0"
   },
   "scripts": {

--- a/src/__mocks__/resource.ts
+++ b/src/__mocks__/resource.ts
@@ -5,7 +5,7 @@ export const tasks = {
   name: "tasks",
   source,
   schema: {
-    $schema: "http://json-schema.org/draft-04/schema#",
+    $schema: "http://json-schema.org/draft-07/schema#",
     title: "tasks",
     type: "object",
     properties: {
@@ -37,7 +37,7 @@ export const users = {
   name: "users",
   source,
   schema: {
-    $schema: "http://json-schema.org/draft-04/schema#",
+    $schema: "http://json-schema.org/draft-07/schema#",
     title: "users",
     type: "object",
     properties: {
@@ -69,7 +69,7 @@ export const projects = {
   name: "projects",
   source,
   schema: {
-    $schema: "http://json-schema.org/draft-04/schema#",
+    $schema: "http://json-schema.org/draft-07/schema#",
     title: "projects",
     type: "object",
     properties: {
@@ -93,7 +93,7 @@ export const departments = {
   name: "departments",
   source,
   schema: {
-    $schema: "http://json-schema.org/draft-04/schema#",
+    $schema: "http://json-schema.org/draft-07/schema#",
     title: "departments",
     type: "object",
     properties: {

--- a/src/__tests__/resource.test.ts
+++ b/src/__tests__/resource.test.ts
@@ -49,7 +49,7 @@ describe(".initialize()", () => {
         has: []
       },
       schema: {
-        $schema: "http://json-schema.org/draft-04/schema#",
+        $schema: "http://json-schema.org/draft-07/schema#",
         properties: {
           name: { type: "string" }
         },

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -48,7 +48,7 @@ export interface Options {
 
 const DEFAULT_RESOURCE: Partial<Resource> = {
   schema: {
-    $schema: "http://json-schema.org/draft-04/schema#",
+    $schema: "http://json-schema.org/draft-07/schema#",
     type: "object",
     properties: {},
     required: [],

--- a/src/security/backend/Resource.ts
+++ b/src/security/backend/Resource.ts
@@ -21,7 +21,7 @@ export class Resource implements Backend {
     this._options = { ...DEFAULT_OPTIONS, ...options };
 
     this.schema = {
-      $schema: "http://json-schema.org/draft-04/schema#",
+      $schema: "http://json-schema.org/draft-07/schema#",
       title: "token",
       type: "object",
 

--- a/src/source/PostgreSQL.ts
+++ b/src/source/PostgreSQL.ts
@@ -319,7 +319,11 @@ const handleConstraintViolation = (error: any): never => {
   (err.output.payload as ValidationFailurePayload).errors = [{
     message: "Constraint violation",
     dataPath: `/${key}`,
-    schemaPath: `/properties/${key}/constraint`
+    schemaPath: `#/properties/${key}/constraint`,
+    keyword: "x-prism-constraint",
+    params: {
+      "x-prism-constraint": key
+    }
   }];
 
   throw err;

--- a/src/source/__tests__/PostgreSQL.test.ts
+++ b/src/source/__tests__/PostgreSQL.test.ts
@@ -101,7 +101,11 @@ describe("#create()", () => {
       expect(error.output.payload.errors).toEqual([{
         message: "Constraint violation",
         dataPath: "/owner",
-        schemaPath: "/properties/owner/constraint"
+        schemaPath: "#/properties/owner/constraint",
+        keyword: "x-prism-constraint",
+        params: {
+          "x-prism-constraint": "owner"
+        }
       }]);
 
       done();
@@ -764,7 +768,11 @@ describe("#update()", () => {
       expect(error.output.payload.errors).toEqual([{
         message: "Constraint violation",
         dataPath: "/owner",
-        schemaPath: "/properties/owner/constraint"
+        schemaPath: "#/properties/owner/constraint",
+        keyword: "x-prism-constraint",
+        params: {
+          "x-prism-constraint": "owner"
+        }
       }]);
 
       done();


### PR DESCRIPTION
AJV is faster and more widely used than `tv4`. Since AJV only supports the most recent version of the JSON Schema draft
(`draft-07` at the time of writing), internal references to Schema versions have been updated from `draft-04` to
`draft-07`.

BREAKING CHANGE: The data structure in the error messages returned by 422 responses is unchanged, but the values of
human-readable keys in this structure have changed slightly due to the error messages being generated by AJV instead of
tv4.

BREAKING CHANGE: The Schema version emitted by the built-in `Resource` security Backend has changed from `draft-04` to
`draft-07`.

BREAKING CHANGE: The Schema version emitted by the `DEFAULT_RESOURCE` definition (used by the `Resource` class when no
Resource configuration is given) has changed from `draft-04` to `draft-07`.